### PR TITLE
Refactor resolver registration and add caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Python library for resolving media URLs to direct download links from various 
 - **Asynchronous**: Built with `async/await` for efficient handling of multiple requests.
 - **Easy to use**: Simple API with intuitive method names.
 - **Extensible**: Support for multiple file hosting platforms.
+- **Caching**: Built-in caching for faster resolution of repeated requests.
 - **Error handling**: Robust error handling for various edge cases.
 - **URL validation**: Built-in URL validation before processing.
 - **Type-hinted**: Fully type-hinted codebase for better readability and maintainability.
@@ -27,16 +28,24 @@ import asyncio
 from truelink import TrueLinkResolver
 
 async def main():
+    # Check if a URL is supported without creating an instance
+    if TrueLinkResolver.is_supported("https://buzzheavier.com/rnk4ut0lci9y"):
+        print("BuzzHeavier is supported!")
+
     resolver = TrueLinkResolver()
     url = "https://buzzheavier.com/rnk4ut0lci9y"
 
     try:
-        if resolver.is_supported(url):
-            result = await resolver.resolve(url)
-            print(type(result))
-            print(result)
-        else:
-            print(f"URL not supported: {url}")
+        # Resolve the URL with caching enabled
+        result = await resolver.resolve(url, use_cache=True)
+        print(type(result))
+        print(result)
+
+        # The second time, the result will be loaded from the cache
+        result = await resolver.resolve(url, use_cache=True)
+        print("Resolved from cache:")
+        print(result)
+
     except Exception as e:
         print(f"Error processing {url}: {e}")
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,16 +28,37 @@ asyncio.run(main())
 
 The `resolve()` method returns a `LinkResult` or `FolderResult` object, depending on the type of link. You can find more information about these objects in the [API Reference](core.md).
 
+## Caching
+
+TrueLink has a built-in caching mechanism to speed up repeated requests for the same URL. To use it, simply pass the `use_cache=True` argument to the `resolve()` method:
+
+```python
+import asyncio
+from truelink import TrueLinkResolver
+
+async def main():
+    resolver = TrueLinkResolver()
+    url = "https://buzzheavier.com/rnk4ut0lci9y"
+
+    # The first time, the URL will be resolved and the result will be cached
+    result1 = await resolver.resolve(url, use_cache=True)
+    print(f"First result: {result1}")
+
+    # The second time, the result will be loaded from the cache
+    result2 = await resolver.resolve(url, use_cache=True)
+    print(f"Second result: {result2}")
+
+asyncio.run(main())
+```
+
 ## Checking for Supported URLs
 
-Before attempting to resolve a URL, you can check if it's supported by TrueLink using the `is_supported()` method:
+You can check if a URL is supported by TrueLink using the static method `is_supported()` without creating an instance of `TrueLinkResolver`:
 
 ```python
 from truelink import TrueLinkResolver
 
-resolver = TrueLinkResolver()
-
-if resolver.is_supported("https://www.mediafire.com/file/somefile"):
+if TrueLinkResolver.is_supported("https://www.mediafire.com/file/somefile"):
     print("This URL is supported!")
 else:
     print("This URL is not supported.")
@@ -45,12 +66,11 @@ else:
 
 ## Listing Supported Domains
 
-You can get a list of all supported domains using the `get_supported_domains()` method:
+You can get a list of all supported domains using the static method `get_supported_domains()`:
 
 ```python
 from truelink import TrueLinkResolver
 
-resolver = TrueLinkResolver()
-supported_domains = resolver.get_supported_domains()
+supported_domains = TrueLinkResolver.get_supported_domains()
 print(supported_domains)
 ```

--- a/src/truelink/resolvers/base.py
+++ b/src/truelink/resolvers/base.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 class BaseResolver(ABC):
     """Base class for all resolvers"""
 
+    DOMAINS: list[str] = []
     USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:122.0) Gecko/20100101 Firefox/122.0"
 
     def __init__(self) -> None:

--- a/src/truelink/resolvers/buzzheavier.py
+++ b/src/truelink/resolvers/buzzheavier.py
@@ -13,6 +13,8 @@ from .base import BaseResolver
 class BuzzHeavierResolver(BaseResolver):
     """Resolver for BuzzHeavier URLs"""
 
+    DOMAINS = ["buzzheavier.com"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve BuzzHeavier URL"""
         pattern = r"^https?://buzzheavier.com/[a-zA-Z0-9]+$"

--- a/src/truelink/resolvers/devuploads.py
+++ b/src/truelink/resolvers/devuploads.py
@@ -12,6 +12,8 @@ from .base import BaseResolver
 class DevUploadsResolver(BaseResolver):
     """Resolver for DevUploads URLs"""
 
+    DOMAINS = ["devuploads.com", "devuploads.net"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve DevUploads URL"""
         try:

--- a/src/truelink/resolvers/doodstream.py
+++ b/src/truelink/resolvers/doodstream.py
@@ -16,6 +16,33 @@ from .base import BaseResolver
 class DoodStreamResolver(BaseResolver):
     """Resolver for DoodStream URLs (dood.watch, dood.to, etc.)"""
 
+    DOMAINS = [
+        "dood.watch",
+        "doodstream.com",
+        "dood.to",
+        "dood.so",
+        "dood.cx",
+        "dood.la",
+        "dood.ws",
+        "dood.sh",
+        "doodstream.co",
+        "dood.pm",
+        "dood.wf",
+        "dood.re",
+        "dood.video",
+        "dooood.com",
+        "dood.yt",
+        "doods.yt",
+        "dood.stream",
+        "doods.pro",
+        "ds2play.com",
+        "d0o0d.com",
+        "ds2video.com",
+        "do0od.com",
+        "d000d.com",
+        "vide0.net",
+    ]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve DoodStream URL"""
         try:

--- a/src/truelink/resolvers/fichier.py
+++ b/src/truelink/resolvers/fichier.py
@@ -17,6 +17,8 @@ PASSWORD_ERROR_MESSAGE_FICHIER = (
 class FichierResolver(BaseResolver):
     """Resolver for 1Fichier.com URLs"""
 
+    DOMAINS = ["1fichier.com"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve 1Fichier.com URL"""
 

--- a/src/truelink/resolvers/filepress.py
+++ b/src/truelink/resolvers/filepress.py
@@ -12,6 +12,8 @@ from .base import BaseResolver
 class FilePressResolver(BaseResolver):
     """Resolver for FilePress URLs (via filebee.xyz)"""
 
+    DOMAINS = ["filepress"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve FilePress URL"""
         try:

--- a/src/truelink/resolvers/fuckingfast.py
+++ b/src/truelink/resolvers/fuckingfast.py
@@ -11,6 +11,8 @@ from .base import BaseResolver
 class FuckingFastResolver(BaseResolver):
     """Resolver for FuckingFast URLs"""
 
+    DOMAINS = ["fuckingfast.co"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve FuckingFast URL"""
         try:

--- a/src/truelink/resolvers/gofile.py
+++ b/src/truelink/resolvers/gofile.py
@@ -17,6 +17,8 @@ PASSWORD_ERROR_MESSAGE = (
 class GoFileResolver(BaseResolver):
     """Resolver for GoFile.io URLs."""
 
+    DOMAINS = ["gofile.io"]
+
     def __init__(self) -> None:
         super().__init__()
         self._folder_details: FolderResult | None = None

--- a/src/truelink/resolvers/krakenfiles.py
+++ b/src/truelink/resolvers/krakenfiles.py
@@ -14,6 +14,8 @@ from .base import BaseResolver
 class KrakenFilesResolver(BaseResolver):
     """Resolver for KrakenFiles.com URLs"""
 
+    DOMAINS = ["krakenfiles.com"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve KrakenFiles.com URL"""
         try:

--- a/src/truelink/resolvers/linkbox.py
+++ b/src/truelink/resolvers/linkbox.py
@@ -13,6 +13,13 @@ from .base import BaseResolver
 class LinkBoxResolver(BaseResolver):
     """Resolver for LinkBox.to URLs"""
 
+    DOMAINS = [
+        "linkbox.to",
+        "lbx.to",
+        "linkbox.cloud",
+        "teltobx.net",
+        "telbx.net",
+    ]
     BASE_API = "https://www.linkbox.to/api/file"
 
     def __init__(self) -> None:

--- a/src/truelink/resolvers/lulacloud.py
+++ b/src/truelink/resolvers/lulacloud.py
@@ -9,6 +9,8 @@ from .base import BaseResolver
 class LulaCloudResolver(BaseResolver):
     """Resolver for LulaCloud URLs"""
 
+    DOMAINS = ["lulacloud.com"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve LulaCloud URL"""
         try:

--- a/src/truelink/resolvers/mediafile.py
+++ b/src/truelink/resolvers/mediafile.py
@@ -12,6 +12,8 @@ from .base import BaseResolver
 class MediaFileResolver(BaseResolver):
     """Resolver for MediaFile.cc URLs"""
 
+    DOMAINS = ["mediafile.cc"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve MediaFile.cc URL"""
         try:

--- a/src/truelink/resolvers/mediafire.py
+++ b/src/truelink/resolvers/mediafire.py
@@ -22,6 +22,8 @@ PASSWORD_ERROR_MESSAGE = (
 class MediaFireResolver(BaseResolver):
     """Resolver for MediaFire URLs (files and folders)"""
 
+    DOMAINS = ["mediafire.com"]
+
     async def _run_sync(self, func, *args, **kwargs):
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, lambda: func(*args, **kwargs))

--- a/src/truelink/resolvers/onedrive.py
+++ b/src/truelink/resolvers/onedrive.py
@@ -13,6 +13,8 @@ from .base import BaseResolver
 class OneDriveResolver(BaseResolver):
     """Resolver for OneDrive (1drv.ms) URLs"""
 
+    DOMAINS = ["1drv.ms", "onedrive.live.com"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve OneDrive URL"""
         try:

--- a/src/truelink/resolvers/pcloud.py
+++ b/src/truelink/resolvers/pcloud.py
@@ -14,6 +14,8 @@ from .base import BaseResolver
 class PCloudResolver(BaseResolver):
     """Resolver for pCloud.link URLs"""
 
+    DOMAINS = ["u.pcloud.link", "pcloud.com"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve pCloud.link URL"""
         try:

--- a/src/truelink/resolvers/pixeldrain.py
+++ b/src/truelink/resolvers/pixeldrain.py
@@ -11,6 +11,8 @@ from .base import BaseResolver
 class PixelDrainResolver(BaseResolver):
     """Resolver for PixelDrain URLs"""
 
+    DOMAINS = ["pixeldrain.com", "pixeldra.in"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve PixelDrain URL"""
         try:

--- a/src/truelink/resolvers/ranoz.py
+++ b/src/truelink/resolvers/ranoz.py
@@ -12,6 +12,8 @@ from .base import BaseResolver
 class RanozResolver(BaseResolver):
     """Resolver for Ranoz.gg URLs"""
 
+    DOMAINS = ["ranoz.gg"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve Ranoz.gg URL"""
         try:

--- a/src/truelink/resolvers/streamtape.py
+++ b/src/truelink/resolvers/streamtape.py
@@ -14,6 +14,16 @@ from .base import BaseResolver
 class StreamtapeResolver(BaseResolver):
     """Resolver for Streamtape URLs"""
 
+    DOMAINS = [
+        "streamtape.com",
+        "streamtape.co",
+        "streamtape.cc",
+        "streamtape.to",
+        "streamtape.net",
+        "streamta.pe",
+        "streamtape.xyz",
+    ]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve Streamtape URL"""
         try:

--- a/src/truelink/resolvers/swisstransfer.py
+++ b/src/truelink/resolvers/swisstransfer.py
@@ -12,6 +12,8 @@ from .base import BaseResolver
 class SwissTransferResolver(BaseResolver):
     """Resolver for SwissTransfer.com URLs"""
 
+    DOMAINS = ["swisstransfer.com"]
+
     async def _get_file_metadata(
         self,
         transfer_id: str,

--- a/src/truelink/resolvers/terabox.py
+++ b/src/truelink/resolvers/terabox.py
@@ -9,6 +9,26 @@ from .base import BaseResolver
 
 
 class TeraboxResolver(BaseResolver):
+    DOMAINS = [
+        "terabox.com",
+        "nephobox.com",
+        "4funbox.com",
+        "mirrobox.com",
+        "momerybox.com",
+        "teraboxapp.com",
+        "1024tera.com",
+        "terabox.app",
+        "gibibox.com",
+        "goaibox.com",
+        "terasharelink.com",
+        "teraboxlink.com",
+        "freeterabox.com",
+        "1024terabox.com",
+        "teraboxshare.com",
+        "terafileshare.com",
+        "terabox.club",
+    ]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         if "/file/" in url and ("terabox.com" in url or "teraboxapp.com" in url):
             filename, size, mime_type = await self._fetch_file_details(url)

--- a/src/truelink/resolvers/tmpsend.py
+++ b/src/truelink/resolvers/tmpsend.py
@@ -11,6 +11,8 @@ from .base import BaseResolver
 class TmpSendResolver(BaseResolver):
     """Resolver for TmpSend.com URLs"""
 
+    DOMAINS = ["tmpsend.com"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve TmpSend.com URL"""
         try:

--- a/src/truelink/resolvers/uploadee.py
+++ b/src/truelink/resolvers/uploadee.py
@@ -11,6 +11,8 @@ from .base import BaseResolver
 class UploadEeResolver(BaseResolver):
     """Resolver for Upload.ee URLs"""
 
+    DOMAINS = ["upload.ee"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve Upload.ee URL"""
         try:

--- a/src/truelink/resolvers/uploadhaven.py
+++ b/src/truelink/resolvers/uploadhaven.py
@@ -14,6 +14,8 @@ from .base import BaseResolver
 class UploadHavenResolver(BaseResolver):
     """Resolver for UploadHaven URLs"""
 
+    DOMAINS = ["uploadhaven.com"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve UploadHaven URL"""
         try:

--- a/src/truelink/resolvers/wetransfer.py
+++ b/src/truelink/resolvers/wetransfer.py
@@ -12,6 +12,8 @@ from .base import BaseResolver
 class WeTransferResolver(BaseResolver):
     """Resolver for WeTransfer.com URLs"""
 
+    DOMAINS = ["wetransfer.com", "we.tl"]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve WeTransfer.com URL"""
         try:

--- a/src/truelink/resolvers/yandexdisk.py
+++ b/src/truelink/resolvers/yandexdisk.py
@@ -15,6 +15,8 @@ YANDEX_DISK_URL_PATTERN = re.compile(
 class YandexDiskResolver(BaseResolver):
     """Resolver for Yandex.Disk URLs"""
 
+    DOMAINS = ["yadi.sk", "disk.yandex." ]
+
     async def resolve(self, url: str) -> LinkResult | FolderResult:
         """Resolve Yandex.Disk URL"""
         if not YANDEX_DISK_URL_PATTERN.match(url):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,26 @@
+import pytest
+from truelink.core import TrueLinkResolver
+
+def test_get_supported_domains():
+    """Test that get_supported_domains returns a list of strings."""
+    domains = TrueLinkResolver.get_supported_domains()
+    assert isinstance(domains, list)
+    assert all(isinstance(domain, str) for domain in domains)
+
+def test_is_supported():
+    """Test that is_supported returns a boolean."""
+    assert isinstance(TrueLinkResolver.is_supported("https://www.google.com"), bool)
+
+@pytest.mark.asyncio
+async def test_caching():
+    """Test that caching works as expected."""
+    resolver = TrueLinkResolver()
+    url = "https://www.mediafire.com/file/cw7xsnxna2xfg4k/K4.part7.rar/file"
+
+    # The first time, the URL will be resolved and the result will be cached
+    result1 = await resolver.resolve(url, use_cache=True)
+
+    # The second time, the result will be loaded from the cache
+    result2 = await resolver.resolve(url, use_cache=True)
+
+    assert result1 is result2

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,0 +1,26 @@
+import pytest
+from truelink.core import TrueLinkResolver
+
+@pytest.mark.asyncio
+async def test_mediafire_folder():
+    """Test that the mediafire folder link resolves correctly."""
+    resolver = TrueLinkResolver()
+    url = "https://www.mediafire.com/folder/abdc8fr8j9nd2/K4"
+    result = await resolver.resolve(url)
+    assert result is not None
+
+@pytest.mark.asyncio
+async def test_mediafire_file():
+    """Test that the mediafire file link resolves correctly."""
+    resolver = TrueLinkResolver()
+    url = "https://www.mediafire.com/file/cw7xsnxna2xfg4k/K4.part7.rar/file"
+    result = await resolver.resolve(url)
+    assert result is not None
+
+@pytest.mark.asyncio
+async def test_terabox_link():
+    """Test that the terabox link resolves correctly."""
+    resolver = TrueLinkResolver()
+    url = "https://terabox.com/s/1vDkjtJWtIOcwr8swIOIBwQ"
+    result = await resolver.resolve(url)
+    assert result is not None


### PR DESCRIPTION
This commit refactors the resolver registration to be dynamic, improving maintainability and making it easier to add new resolvers. It also introduces a caching mechanism to improve performance for repeated requests.

The following changes were made:

- The `_resolvers` dictionary in `TrueLinkResolver` is now populated dynamically by discovering resolvers in the `src/truelink/resolvers` directory.
- The `is_supported` and `get_supported_domains` methods have been converted to static methods.
- A caching mechanism has been added to the `resolve` method, which can be enabled with the `use_cache` parameter.
- The documentation and examples have been updated to reflect the changes.
- Added a basic test suite to verify the new features.