### PR TITLE
Add watchadsontape.com support and streamtape.net fallback for StreamtapeResolver

### DIFF
--- a/src/truelink/__init__.py
+++ b/src/truelink/__init__.py
@@ -4,7 +4,7 @@ from .core import TrueLinkResolver
 from .exceptions import TrueLinkException, UnsupportedProviderException
 from .types import FolderResult, LinkResult
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __all__ = [
     "FolderResult",
     "LinkResult",


### PR DESCRIPTION
## Summary
Enhanced the StreamtapeResolver to improve reliability and add support for an additional Streamtape domain.

## Changes Made
- ✅ Added `watchadsontape.com` to supported domains list
- ✅ Implemented automatic fallback to `streamtape.net` when original domain fails
- ✅ Added domain switching logic to handle unreliable domain access
- ✅ Updated referer headers to use the working domain

## Problem Solved
- **New Domain Support**: `watchadsontape.com` URLs were previously unsupported
- **Reliability Issues**: Some Streamtape domains (like `.com`) occasionally fail while others (like `.net`) work fine
- **User Experience**: Automatic fallback prevents extraction failures due to temporary domain issues

## Implementation Details
- Added `_try_with_fallback_domain()` method for domain switching
- Maintains video ID consistency across domain changes  
- Uses `streamtape.net` as the primary fallback domain (most reliable)
- Preserves all existing functionality while adding robustness

## Testing
- [x] Tested with existing Streamtape domains
- [x] Tested with new `watchadsontape.com` domain
- [x] Tested fallback mechanism when primary domain fails
- [x] Verified extracted links work correctly

## Backward Compatibility
✅ Fully backward compatible - no breaking changes to existing functionality

This enhancement improves the resolver's reliability and extends support to cover more Streamtape domain variations.

## Summary by Sourcery

Enhance StreamtapeResolver to support an additional domain and improve extraction reliability through automatic domain fallback

New Features:
- Add support for watchadsontape.com in the StreamtapeResolver domain list

Enhancements:
- Implement a fallback mechanism that retries failed requests using streamtape.net
- Update referer headers to reflect the active domain for direct video URL requests