### PR TITLE
fix(ci): use uv sync and uv run in format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -31,16 +31,16 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv lock --upgrade
+          uv sync --all-extras
 
       - name: Run ruff to lint and format code
         run: |
-          uv tool run ruff check . --exit-zero
-          uv tool run ruff format .
+          uv run ruff check . --exit-zero
+          uv run ruff format .
 
       - name: Run ty to type check code
         run: |
-          uv tool run ty check .
+          uv run ty check .
 
       - name: Commit and push changes
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,9 +120,6 @@ ignore = [
 [tool.ty.src]
 include = ["src", "docs"]
 
-[tool.ty.environment]
-root = ["./src"]
-
 [tool.ty.rules]
 unused-ignore-comment = "warn"
 redundant-cast = "ignore"

--- a/uv.lock
+++ b/uv.lock
@@ -1367,6 +1367,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "cloudscraper" },
     { name = "lxml" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -1402,6 +1403,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.5" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.1a17" },
+    { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
 provides-extras = ["dev", "docs"]
 


### PR DESCRIPTION
The `format.yml` workflow was failing in the `ty check` step due to `unresolved-import` errors. This was happening for two reasons:

1.  `uv tool run` executes tools in an isolated virtual environment, which does not have access to the project's dependencies.
2.  `uv lock --upgrade` was used to install dependencies, but it does not install optional dependencies (extras) by default.

This commit fixes the workflow by:
- Replacing `uv lock --upgrade` with `uv sync --all-extras` to ensure all dependencies, including the `dev` and `docs` extras, are installed.
- Replacing `uv tool run` with `uv run` to execute the tools within the project's environment, giving them access to all the installed dependencies.

## Summary by Sourcery

Fix format CI workflow to properly install dependencies and run code quality tools in the project environment

CI:
- Use uv sync --all-extras instead of uv lock --upgrade to install all dependencies and extras
- Replace uv tool run with uv run for ruff lint/format and ty type checking

Chores:
- Remove obsolete [tool.ty.environment] section from pyproject.toml