### PR TITLE
Update streamtape.py

### DIFF
--- a/src/truelink/resolvers/streamtape.py
+++ b/src/truelink/resolvers/streamtape.py
@@ -27,6 +27,7 @@ class StreamtapeResolver(BaseResolver):
         "streamta.pe",
         "streamtape.xyz",
         "watchadsontape.com",
+        "strcloud.club",
     ]
 
     # Use only streamtape.net as fallback domain


### PR DESCRIPTION
added domain support for strcloud.club

## Summary by Sourcery

Enhancements:
- Include "strcloud.club" in the list of supported Streamtape domains