### PR TITLE
Update xham.py

### DIFF
--- a/src/truelink/resolvers/xham.py
+++ b/src/truelink/resolvers/xham.py
@@ -2,8 +2,10 @@
 # ---------------
 from __future__ import annotations
 
+import re
 from typing import ClassVar
 from urllib.parse import urlparse, urlunparse
+from os.path import basename
 
 from truelink.exceptions import ExtractionFailedException
 from truelink.types import FolderResult, LinkResult
@@ -12,7 +14,9 @@ from .base import BaseResolver
 
 
 class XhamResolver(BaseResolver):
-    """Resolver for xhamster variants via EasyDownloader API, normalizing host to xhamster.desi before processing."""
+    """Resolver for xhamster variants via vidquickly API,
+    normalizing host to xhamster1.desi before processing.
+    """
 
     DOMAINS: ClassVar[list[str]] = [
         "xhamster.com",
@@ -22,108 +26,85 @@ class XhamResolver(BaseResolver):
         "xhaccess.com",
     ]
 
-    API_URL: ClassVar[str] = "https://api.easydownloader.app/api-extract"
-    API_KEY: ClassVar[str] = "175p40401h9m2rcmvdo-epdagr-egmadidn-eri-hcE"
+    API_URL: ClassVar[str] = (
+        "https://vidquickly.com/api/v1/xhamster-get-link?url="
+    )
+
     CANONICAL_HOST: ClassVar[str] = "xhamster1.desi"
 
     def _normalize_to_canonical(self, original_url: str) -> str:
-        """Replace supported domains with xhamster.desi using netloc only; keep scheme/path/query/fragment."""
-        parsed = urlparse(original_url)  # parse URL into parts [11]
+        """Replace supported domains with xhamster1.desi using netloc only."""
+        parsed = urlparse(original_url)
+
         to_replace = {
             "xhamster.com",
             "xhamster19.com",
             "xhamster1.desi",
             "xhamster2.com",
             "xhaccess.com",
-        }  # exact netloc matches [11]
-        if parsed.netloc in to_replace:
-            replaced = parsed._replace(
-                netloc=self.CANONICAL_HOST
-            )  # swap netloc only [11]
-            return urlunparse(replaced)  # reassemble URL preserving other parts [11]
-        return original_url  # not in our set; return unchanged [11]
-
-    async def resolve(self, url: str) -> LinkResult | FolderResult:
-        # Normalize to canonical host if matched
-        canonical_url = self._normalize_to_canonical(
-            url
-        )  # netloc-based canonicalization [11]
-
-        payload = {
-            "video_url": canonical_url,
-            "pagination": False,
-            "key": self.API_KEY,
         }
 
+        if parsed.netloc in to_replace:
+            replaced = parsed._replace(netloc=self.CANONICAL_HOST)
+            return urlunparse(replaced)
+
+        return original_url
+
+    def _extract_quality(self, title: str) -> int:
+        """Extract numeric quality from title like 'Video 720p'."""
+        match = re.search(r"(\d+)", title or "")
+        return int(match.group(1)) if match else 0
+
+    async def resolve(self, url: str) -> LinkResult | FolderResult:
+        canonical_url = self._normalize_to_canonical(url)
+
+        api_url = self.API_URL + canonical_url
+
         try:
-            # POST to the EasyDownloader API
-            async with await self._post(self.API_URL, json=payload) as response:
+            async with await self._get(api_url) as response:
                 if response.status != 200:
                     error_text = await response.text()
-                    self._raise_extraction_failed(
-                        f"EasyDownloader API error ({response.status}): {error_text[:200]}"
+                    raise ExtractionFailedException(
+                        f"vidquickly API error ({response.status}): {error_text[:200]}"
                     )
+
                 try:
                     data = await response.json()
                 except Exception as e:
                     snippet = await response.text()
-                    msg = f"Failed to parse JSON: {e} - Response: {snippet[:200]}"
-                    raise ExtractionFailedException(msg) from e
+                    raise ExtractionFailedException(
+                        f"Failed to parse JSON: {e} - Response: {snippet[:200]}"
+                    ) from e
 
-            # Expecting a structure similar to: {"final_urls": [{"links": [...], "file_name": "...", "file_type": "...", ...}]}
-            final_urls = data.get("final_urls", [])
-            if not isinstance(final_urls, list) or not final_urls:
-                msg = "No final_urls found in API response"
-                raise ExtractionFailedException(msg)
+            links = data.get("links", [])
 
-            block = final_urls[0]  # take first block as in other resolvers
-            links = block.get("links", [])
             if not isinstance(links, list) or not links:
-                msg = "No links found inside final_urls"
-                raise ExtractionFailedException(msg)
+                raise ExtractionFailedException("No direct MP4 links found")
 
-            # Attempt to take filename/mime from block if present (as per API fields)
-            block_filename = block.get("file_name")  # API-provided filename [2][5]
-            block_mime = (
-                block.get("file_type") or "application/octet-stream"
-            )  # API-provided type or fallback [2][5]
+            # 🔥 Select best quality (highest resolution)
+            best = max(
+                links,
+                key=lambda x: self._extract_quality(x.get("title", "")),
+            )
 
-            # Preferred quality order
-            preferred_qualities = ["720p", "480p", "240p"]
+            link_url = best.get("url")
+            if not link_url:
+                raise ExtractionFailedException("Selected link has no URL")
 
-            # Choose best quality link
-            chosen = None
-            for q in preferred_qualities:
-                for link in links:
-                    if link.get("file_quality") == q and link.get("link_url"):
-                        chosen = link
-                        break
-                if chosen:
-                    break
+            # Filename from URL or videoDetails title
+            filename = None
+            video_details = data.get("videoDetails", {})
+            title = video_details.get("title")
 
-            if not chosen:
-                # If no preferred quality, optionally pick the first available valid link
-                for link in links:
-                    if link.get("link_url"):
-                        chosen = link
-                        break
+            if title:
+                safe_title = re.sub(r"[^\w\-_. ]", "", title)
+                filename = f"{safe_title}.mp4"
+            else:
+                filename = basename(urlparse(link_url).path)
 
-            if not chosen:
-                msg = "Failed to find a usable download link in preferred qualities"
-                raise ExtractionFailedException(msg)
+            mime_type = "video/mp4"
+            size = None  # API does not provide size
 
-            # Map fields from chosen link and/or block for LinkResult parity with Terabox
-            link_url = chosen.get("link_url")
-            # Prefer more specific per-link fields if present; otherwise use block-level metadata
-            filename = (
-                chosen.get("file_name") or block_filename or None
-            )  # name source [2][5]
-            mime_type = (
-                chosen.get("file_type") or block_mime or "application/octet-stream"
-            )  # MIME [2][5]
-            size = (
-                chosen.get("file_size") or None
-            )  # may be absent; keep None if not provide
             return LinkResult(
                 url=link_url,
                 filename=filename,
@@ -132,8 +113,6 @@ class XhamResolver(BaseResolver):
             )
 
         except Exception as e:
-            msg = f"Failed to resolve domain URL: {e}"
-            raise ExtractionFailedException(msg) from e
-
-    def _raise_extraction_failed(self, msg: str) -> None:
-        raise ExtractionFailedException(msg)
+            raise ExtractionFailedException(
+                f"Failed to resolve domain URL: {e}"
+            ) from e


### PR DESCRIPTION
API UPDATED !!

## Summary by Sourcery

Switch XhamResolver to use the vidquickly API with xhamster1.desi as the canonical host and update link selection and error handling accordingly.

Enhancements:
- Update XhamResolver to call the vidquickly API via GET instead of the EasyDownloader API and remove the API key dependency.
- Change canonical domain normalization to xhamster1.desi and simplify URL handling.
- Improve link selection by choosing the highest available quality based on numeric resolution parsed from link titles and always returning MP4 metadata.
- Streamline error handling and JSON parsing failures into consistent ExtractionFailedException messages.